### PR TITLE
[feat] recommend activitycard api 연결

### DIFF
--- a/fe/src/apis/main/program.ts
+++ b/fe/src/apis/main/program.ts
@@ -1,4 +1,5 @@
-import axiosInstance from "@/apis/common/axiosMainInstance";
+import axiosMainInstance from "@/apis/common/axiosMainInstance";
+import axiosAiInstance from "@/apis/common/axiosAiInstance";
 import { handleApiError } from "@/utils/common/handleApiError";
 import type { AxiosResponse } from "axios";
 
@@ -32,17 +33,72 @@ export interface Program {
   imageUrl: string;
 }
 
+interface RecommendedProgramResponse {
+  id: number;
+  name: string;
+  firDay: string;
+  secDay: string;
+  thrDay: string;
+  fouDay: string;
+  fivDay: string;
+  startTime: {
+    hour: number;
+    minute: number;
+    second: number;
+    nano: number;
+  };
+  endTime: {
+    hour: number;
+    minute: number;
+    second: number;
+    nano: number;
+  };
+  price: number;
+  mainCategory: string;
+  subCategory: string;
+  headcount: string;
+  tags: { name: string }[];
+  center?: {
+    id: number;
+    name: string;
+  };
+  image_url?: string;
+  imageUrl?: string;
+}
+
 export async function fetchProgramList(): Promise<Program[]> {
   try {
     const res: AxiosResponse<{ success: boolean; data: Program[] }> =
-      await axiosInstance.get("/v1/program/all");
+      await axiosMainInstance.get("/v1/program/all");
 
-    if (!res.data.success) {
+    if (!res.data.success)
       throw new Error("프로그램 목록을 불러오지 못했습니다.");
-    }
 
     return res.data.data;
   } catch (error) {
     throw handleApiError(error, "프로그램 목록 조회 중 오류가 발생했습니다.");
+  }
+}
+
+export async function fetchRecommendedPrograms(
+  subCategory?: string,
+): Promise<Program[]> {
+  try {
+    const res: AxiosResponse<RecommendedProgramResponse[]> =
+      await axiosAiInstance.get("/recommend", {
+        params: subCategory ? { sub_category: subCategory } : {},
+      });
+
+    const converted: Program[] = res.data.map((item) => ({
+      ...item,
+      imageUrl: item.image_url ?? item.imageUrl ?? "",
+      centerId: item.center?.id ?? 0,
+      centerName: item.center?.name ?? "장소 정보 없음",
+      tags: item.tags.map((t) => t.name),
+    }));
+
+    return converted;
+  } catch (error: unknown) {
+    throw handleApiError(error, "추천 프로그램 조회 중 오류가 발생했습니다.");
   }
 }

--- a/fe/src/app/guest/page.tsx
+++ b/fe/src/app/guest/page.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import { useState } from "react";
-
 import MainHeader from "@/components/home/MainHeader";
 import SearchBar from "@/components/home/SearchBar";
-import ActivityCardList from "@/components/home/ActivityCardList";
+import GuestActivityCardList from "@/components/home/GuestActivityCardList";
 import BottomNavBar from "@/components/common/BottomNavBar";
 import LoginGuidePopup from "@/components/auth/popup/LoginGuidePopup";
 
@@ -16,7 +15,7 @@ export default function GuestPage() {
       <MainHeader />
       <div className="flex flex-col gap-6 px-5 pt-[122px] pb-[124px] bg-bgColor-default">
         <SearchBar />
-        <ActivityCardList />
+        <GuestActivityCardList />
       </div>
       <BottomNavBar />
       <LoginGuidePopup

--- a/fe/src/app/member/page.tsx
+++ b/fe/src/app/member/page.tsx
@@ -1,6 +1,6 @@
 import MainHeader from "@/components/home/MainHeader";
 import SearchBar from "@/components/home/SearchBar";
-import ActivityCardList from "@/components/home/ActivityCardList";
+import MemberActivityCardList from "@/components/home/MemberActivityCardList";
 import BottomNavBar from "@/components/common/BottomNavBar";
 
 export default function MemberPage() {
@@ -9,7 +9,7 @@ export default function MemberPage() {
       <MainHeader />
       <div className="flex flex-col gap-6 px-5 pt-[122px] pb-[124px] bg-bgColor-default">
         <SearchBar />
-        <ActivityCardList />
+        <MemberActivityCardList />
       </div>
       <BottomNavBar />
     </>

--- a/fe/src/components/home/GuestActivityCardList.tsx
+++ b/fe/src/components/home/GuestActivityCardList.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import ActivityCardListBase from "./ActivityCardListBase";
+import { fetchProgramList, Program } from "@/apis/main/program";
+import { useAuth } from "@/hooks/auth/useAuth";
+
+export default function GuestActivityCardList() {
+  const { hydrated } = useAuth();
+  const [programs, setPrograms] = useState<Program[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadData = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await fetchProgramList();
+      setPrograms(data.slice(0, 5));
+    } catch {
+      setError("활동 목록을 불러오는 데 실패했습니다.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (hydrated) void loadData();
+  }, [hydrated, loadData]);
+
+  return (
+    <ActivityCardListBase
+      programs={programs}
+      isLoading={isLoading}
+      error={error}
+      onReload={loadData}
+    />
+  );
+}

--- a/fe/src/components/home/MainHeader.tsx
+++ b/fe/src/components/home/MainHeader.tsx
@@ -41,11 +41,12 @@ export default function MainHeader() {
       <div className="flex flex-col justify-center text-textColor-heading text-base leading-snug font-pretendard mx-auto h-full">
         {isGuest ? (
           <p>딱! 맞는 활동 추천드릴게요!</p>
+        ) : userName === null ? (
+          <div className="h-[40px] w-[200px]" />
         ) : (
           <>
             <p>
-              <span className="font-semibold">{userName ?? "사용자"}</span>{" "}
-              님에게
+              <span className="font-semibold">{userName}</span> 님에게
             </p>
             <p>딱! 맞는 활동 추천해드릴게요!</p>
           </>

--- a/fe/src/components/home/MemberActivityCardList.tsx
+++ b/fe/src/components/home/MemberActivityCardList.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import ActivityCardListBase from "./ActivityCardListBase";
+import { fetchRecommendedPrograms, Program } from "@/apis/main/program";
+import { useAuth } from "@/hooks/auth/useAuth";
+
+export default function MemberActivityCardList() {
+  const { hydrated } = useAuth();
+  const [programs, setPrograms] = useState<Program[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadData = useCallback(async () => {
+    if (!hydrated) return;
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const data = await fetchRecommendedPrograms();
+      setPrograms(data);
+
+      if (data.length === 0) {
+        setError("추천 가능한 활동이 없습니다.");
+      }
+    } catch {
+      setError("추천 활동을 불러오는 데 실패했습니다.");
+      setPrograms([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [hydrated]);
+
+  useEffect(() => {
+    void loadData();
+  }, [loadData]);
+
+  return (
+    <ActivityCardListBase
+      programs={programs}
+      isLoading={isLoading}
+      error={error}
+      onReload={loadData}
+    />
+  );
+}

--- a/fe/src/hooks/schedule/useSchedules.ts
+++ b/fe/src/hooks/schedule/useSchedules.ts
@@ -51,7 +51,6 @@ export function useSchedules(day: string) {
     void load(day);
   }, [day, load]);
 
-  /** 에러는 호출자에서 catch */
   const remove = async (scheduleId: number) => {
     await deleteSchedule(scheduleId);
     setData((prev) => prev.filter((s) => s.id !== scheduleId));


### PR DESCRIPTION
## 📝 PR 내용 요약

- 성향분석 기반 추천 활동 카드 리스트 구현

## ✅ 작업 상세

- `ai api - recommend` 회원 활동 카드 연동
- `member Header` 리팩토링

## #️⃣ 연관 이슈


## 🖼️ 변경된 화면 (선택)
![스크린샷 2025-05-13 030916](https://github.com/user-attachments/assets/eb3f864e-2444-48e3-8245-26b2fc0eb24d)


## 💬 기타 논의 사항 (선택)

## 💬 리뷰 요구사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 게스트와 회원을 위한 맞춤형 활동 카드 리스트 컴포넌트가 추가되었습니다.
    - AI 추천 프로그램 목록을 불러오는 기능이 도입되었습니다.

- **리팩터**
    - 활동 카드 리스트 컴포넌트가 데이터 및 상태 관리를 외부에서 받는 구조로 개선되었습니다.

- **스타일**
    - 메인 헤더에서 사용자 이름이 없는 경우 시각적 플레이스홀더가 표시됩니다.

- **버그 수정**
    - 없음

- **기타**
    - 불필요한 주석이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->