### PR TITLE
[style]#41 챗봇 하단 스타일 변경 및 마이페이지 버튼 수정

### DIFF
--- a/fe/src/app/member/mypage/page.tsx
+++ b/fe/src/app/member/mypage/page.tsx
@@ -39,7 +39,7 @@ export default function MyPage() {
 
         <FamilyList userInfoList={familyList} />
 
-        <div className="mt-10 mb-8">
+        <div className="mt-20 mb-8">
           <FamilyAddButton />
         </div>
 

--- a/fe/src/components/chatbot/ChatbotHeader.tsx
+++ b/fe/src/components/chatbot/ChatbotHeader.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import type { NextPage } from "next";
+import { useRouter } from "next/navigation";
+import BackButton from "@/components/common/button/BackButton";
+
+interface ChatbotHeaderProps {
+  onBack?: () => void;
+}
+
+const ChatbotHeader: NextPage<ChatbotHeaderProps> = ({ onBack }) => {
+  const router = useRouter();
+
+  const handleBack = (
+    e: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>,
+  ) => {
+    e.preventDefault();
+    if (onBack) {
+      onBack();
+    } else {
+      router.back();
+    }
+  };
+
+  return (
+    <div className="w-full relative bg-white h-14 md:h-16 flex items-center px-2 md:px-4 text-gray font-pretendard">
+      <BackButton onClick={handleBack} className="mr-1" />
+
+      <div className="absolute left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2 font-medium text-[21px] md:text-2xl">
+        챗봇
+      </div>
+    </div>
+  );
+};
+
+export default ChatbotHeader;

--- a/fe/src/components/chatbot/ChatbotHeader.tsx
+++ b/fe/src/components/chatbot/ChatbotHeader.tsx
@@ -25,7 +25,7 @@ const ChatbotHeader: NextPage = () => {
 
   return (
     <div className="w-full relative bg-bgColor-default h-14 md:h-16 flex items-center px-2 md:px-4 text-textColor-heading font-pretendard">
-      <BackButton onClick={handleBackClick} href="/member" className="mr-1" />
+      <BackButton onClick={handleBackClick} className="mr-1" />
 
       <div className="absolute left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2 font-medium text-[21px] md:text-2xl">
         배우다

--- a/fe/src/components/chatbot/ChatbotHeader.tsx
+++ b/fe/src/components/chatbot/ChatbotHeader.tsx
@@ -1,34 +1,39 @@
 "use client";
 
 import type { NextPage } from "next";
-import { useRouter } from "next/navigation";
+import { useState } from "react";
 import BackButton from "@/components/common/button/BackButton";
+import ChatbotExitPopup from "@/components/chatbot/popup/ChatbotExitPopup";
 
-interface ChatbotHeaderProps {
-  onBack?: () => void;
-}
+const ChatbotHeader: NextPage = () => {
+  const [isPopupOpen, setIsPopupOpen] = useState(false);
 
-const ChatbotHeader: NextPage<ChatbotHeaderProps> = ({ onBack }) => {
-  const router = useRouter();
-
-  const handleBack = (
-    e: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>,
-  ) => {
+  const handleBackClick = (e: React.MouseEvent) => {
     e.preventDefault();
-    if (onBack) {
-      onBack();
-    } else {
-      router.back();
-    }
+    setIsPopupOpen(true);
+  };
+
+  const handleConfirmExit = () => {
+    window.location.href = "/member";
+  };
+
+  const handleClosePopup = () => {
+    setIsPopupOpen(false);
   };
 
   return (
-    <div className="w-full relative bg-white h-14 md:h-16 flex items-center px-2 md:px-4 text-gray font-pretendard">
-      <BackButton onClick={handleBack} className="mr-1" />
+    <div className="w-full relative bg-bgColor-default h-14 md:h-16 flex items-center px-2 md:px-4 text-textColor-heading font-pretendard">
+      <BackButton onClick={handleBackClick} href="/member" className="mr-1" />
 
       <div className="absolute left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2 font-medium text-[21px] md:text-2xl">
-        챗봇
+        배우다
       </div>
+
+      <ChatbotExitPopup
+        isOpen={isPopupOpen}
+        onConfirm={handleConfirmExit}
+        onClose={handleClosePopup}
+      />
     </div>
   );
 };

--- a/fe/src/components/chatbot/ChatbotHeader.tsx
+++ b/fe/src/components/chatbot/ChatbotHeader.tsx
@@ -2,10 +2,12 @@
 
 import type { NextPage } from "next";
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import BackButton from "@/components/common/button/BackButton";
 import ChatbotExitPopup from "@/components/chatbot/popup/ChatbotExitPopup";
 
 const ChatbotHeader: NextPage = () => {
+  const router = useRouter();
   const [isPopupOpen, setIsPopupOpen] = useState(false);
 
   const handleBackClick = (e: React.MouseEvent) => {
@@ -14,7 +16,7 @@ const ChatbotHeader: NextPage = () => {
   };
 
   const handleConfirmExit = () => {
-    window.location.href = "/member";
+    router.push("/member");
   };
 
   const handleClosePopup = () => {

--- a/fe/src/components/chatbot/layout/ChatbotBottom.tsx
+++ b/fe/src/components/chatbot/layout/ChatbotBottom.tsx
@@ -20,7 +20,7 @@ const ChatbotBottom: React.FC<ChatbotBottomProps> = ({ onSend }) => {
   };
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 w-full flex justify-center items-end pb-safe z-50">
+    <div className="fixed bottom-0 left-0 right-0 w-full flex justify-center items-end z-50 pb-[env(safe-area-inset-bottom)] sm:pb-0">
       <div className="w-full max-w-[414px] bg-bgColor-default h-[100px] flex items-center justify-center py-6 px-4 gap-2 text-textColor-body font-pretendard shadow">
         <VoiceInput handleSend={onSend} />
         <div className="flex-1 max-w-[320px] h-[54px] rounded-2xl bg-bgColor-default border border-borderColor-default focus-within:border-brand-normal flex items-center justify-between px-3 gap-3 transition">

--- a/fe/src/components/chatbot/layout/ChatbotBottom.tsx
+++ b/fe/src/components/chatbot/layout/ChatbotBottom.tsx
@@ -20,26 +20,27 @@ const ChatbotBottom: React.FC<ChatbotBottomProps> = ({ onSend }) => {
   };
 
   return (
-    <div className="w-full bg-bgColor-default h-[85px] flex items-center justify-center py-4 px-3 gap-2 text-textColor-body font-pretendard">
-      <VoiceInput handleSend={onSend} />
-
-      <div className="w-[294px] h-[54px] rounded-2xl bg-bgColor-default border border-borderColor-default focus-within:border-brand-normal flex items-center justify-between px-3 gap-3 transition">
-        <input
-          ref={inputRef}
-          type="text"
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={(e) => e.key === "Enter" && handleSend()}
-          placeholder="궁금한 내용을 입력해주세요."
-          className="w-full bg-transparent outline-none text-textColor-heading placeholder:text-textColor-sub"
-        />
-        <button onClick={handleSend}>
-          <SendIcon
-            width={36}
-            height={36}
-            className="text-textColor-disabled"
+    <div className="fixed bottom-0 left-0 right-0 w-full flex justify-center items-end pb-safe z-50">
+      <div className="w-full max-w-[414px] bg-bgColor-default h-[100px] flex items-center justify-center py-6 px-4 gap-2 text-textColor-body font-pretendard shadow">
+        <VoiceInput handleSend={onSend} />
+        <div className="flex-1 max-w-[320px] h-[54px] rounded-2xl bg-bgColor-default border border-borderColor-default focus-within:border-brand-normal flex items-center justify-between px-3 gap-3 transition">
+          <input
+            ref={inputRef}
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleSend()}
+            placeholder="궁금한 내용을 입력해주세요."
+            className="w-full bg-transparent outline-none text-textColor-heading placeholder:text-textColor-sub"
           />
-        </button>
+          <button onClick={handleSend}>
+            <SendIcon
+              width={36}
+              height={36}
+              className="text-textColor-disabled"
+            />
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/fe/src/components/chatbot/layout/ChatbotGreeting.tsx
+++ b/fe/src/components/chatbot/layout/ChatbotGreeting.tsx
@@ -12,7 +12,7 @@ const ChatbotGreeting: FC<ChatbotGreetingProps> = ({ username }) => {
           {username}님, 안녕하세요
         </p>
         <p className="m-0 text-[19px] whitespace-pre-wrap">
-          반가워요, 배우다예요!!
+          대화를 시작해보세요!
         </p>
       </div>
     </div>

--- a/fe/src/components/chatbot/messages/ChatbotMessageList.tsx
+++ b/fe/src/components/chatbot/messages/ChatbotMessageList.tsx
@@ -90,7 +90,7 @@ const ChatbotMessageList = () => {
   return (
     <>
       <div className="flex flex-col h-full">
-        <div className="flex-1 overflow-y-auto p-4 min-h-0">
+        <div className="flex-1 overflow-y-auto p-4 pb-[130px] min-h-0">
           {loading && (
             <div className="text-center text-gray-500">로딩 중입니다...</div>
           )}

--- a/fe/src/components/mypage/button/FamilyAddButton.tsx
+++ b/fe/src/components/mypage/button/FamilyAddButton.tsx
@@ -18,7 +18,7 @@ const FamilyAddButton = () => {
     <>
       <button
         onClick={handleOpenPopup}
-        className={`h-[55px] min-w-[245px] px-6 shadow-[0px_3px_10px_rgba(142,_142,_142,_0.3)] 
+        className={`h-[55px] min-w-[330px] px-6 shadow-[0px_3px_10px_rgba(142,_142,_142,_0.3)] 
         rounded-xl bg-brand-normal text-white text-2xl font-semibold font-pretendard 
         whitespace-nowrap flex items-center justify-center`}
       >


### PR DESCRIPTION
## 📝 PR 내용 요약

* 챗봇 입력창 및 마이크 위치 UI 개선
* 마이페이지 버튼 간격 및 배치 수정

## ✅ 작업 상세

* 챗봇 하단 입력창의 마진 및 높이 조정으로 화면 하단 밀착 개선
* 마이크 버튼 위치를 입력창과 정렬되도록 수정
* 마이페이지 내 로그아웃/회원탈퇴 버튼 간격 및 정렬 수정

## #️⃣ 연관 이슈

> Closes #41

## 🖼️ 변경된 화면 (선택)

> (변경된 UI 캡처 이미지 첨부)

## 💬 기타 논의 사항 (선택)



## 💬 리뷰 요구사항 (선택)

* 입력창과 마이크 위치가 정확히 정렬되어 있는지 확인 부탁드립니다
* 앱에서 하단 입력창 위치 패딩 확인 부탁드립니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 챗봇 화면에 뒤로가기 버튼과 제목이 포함된 새로운 헤더가 추가되었습니다.

- **Style**
  - 챗봇 메시지 목록 하단 여백이 늘어나 메시지가 가려지지 않도록 개선되었습니다.
  - 챗봇 입력창 하단 바가 화면 하단에 고정되고, 반응형 레이아웃으로 변경되어 사용성이 향상되었습니다.
  - 가족 추가 버튼의 최소 너비가 넓어져 버튼이 더 크게 표시됩니다.
  - 마이페이지 내 가족 추가 버튼 상단 여백이 증가하여 레이아웃이 개선되었습니다.
  - 챗봇 인사말 문구가 "대화를 시작해보세요!"로 변경되어 사용자 친화적 안내를 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->