### PR TITLE
[refactor] 일정 헤더 UI/UX 개선

### DIFF
--- a/fe/src/components/calendar/CalendarHeader.tsx
+++ b/fe/src/components/calendar/CalendarHeader.tsx
@@ -39,15 +39,16 @@ const CalendarHeader: FC<CalendarHeaderProps> = ({
 
   return (
     <header className="sticky top-0 z-20 w-full bg-white shadow-[0px_3px_10px_rgba(142,142,142,0.25)]">
-      <div className="w-full max-w-[400px] mx-auto pt-4 pb-2 flex items-center px-4 relative">
+      <div className="w-full max-w-[400px] mx-auto pt-4 pb-2 flex items-center px-4">
         <BackButton
           onClick={handleBack}
-          className="mr-4 flex-shrink-0 z-10"
-          iconSize={40}
+          className="flex-shrink-0"
+          iconSize={36}
         />
-        <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-2xl sm:text-3xl font-bold text-textColor-heading w-max pointer-events-none select-none">
+        <div className="flex-1 text-center text-xl sm:text-2xl font-bold text-textColor-heading">
           {monthLabel}
         </div>
+        <div className="w-9 h-9" />
       </div>
 
       <div className="mt-6 grid grid-cols-7 gap-x-2 sm:gap-x-4 justify-items-center mb-2 font-bold px-2">
@@ -62,7 +63,7 @@ const CalendarHeader: FC<CalendarHeaderProps> = ({
               key={d.toISOString()}
               type="button"
               onClick={() => onSelectDay(dayStr)}
-              className={`flex flex-col items-center justify-center w-14 h-16 sm:w-16 sm:h-20 rounded-xl transition-all
+              className={`flex flex-col items-center justify-center w-12 h-16 sm:w-14 sm:h-20 rounded-xl transition-all
                 ${
                   active
                     ? "border-2 border-brand-normal font-extrabold text-brand-normal bg-brand-normal/10"


### PR DESCRIPTION
## 📝 PR 내용 요약

- 일정 페이지 상단 UI 개선 및 요일 시각적 구분을 통해 사용자 흐름을 명확하게 했습니다.

## ✅ 작업 상세

- 일정 페이지에 상단 네비게이션 바 추가
-  상단에 뒤로가기 버튼 추가
- 달력 UI를 주간 단위(일~토)로 변경
- 토요일은 파란색, 일요일은 빨간색으로 요일 색상 구분 적용

## #️⃣ 연관 이슈

> Closes #46 

## 🖼️ 변경된 화면 (선택)
![image](https://github.com/user-attachments/assets/5d8f4b36-c187-4552-841d-16b0b630ce08)


## 💬 기타 논의 사항 (선택)

## 💬 리뷰 요구사항 (선택)
- 일정 헤더 깨짐 현상 해결 및 노인친화UI 적용하기 위한 구현 코드 방식 어떤지 확인 부탁드려요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 캘린더 헤더에 뒤로가기 버튼이 추가되어, 로그인 상태에 따라 "/guest" 또는 "/member"로 이동할 수 있습니다.

- **UI 개선**
  - 캘린더가 오늘부터 연속된 7일(일요일 포함)을 표시하도록 변경되었습니다.
  - 일요일과 토요일이 각각 빨간색, 파란색으로 구분되어 표시됩니다.
  - 선택된 날짜는 테두리와 배경색으로 강조됩니다.
  - 버튼 크기와 글씨 크기가 개선되어 반응형 및 일관성 있는 스타일이 적용되었습니다.
  - 헤더 레이아웃이 균형 있게 재구성되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->