### PR TITLE
[fix] 로딩 UI 중앙 정렬 버그 수정

### DIFF
--- a/fe/src/app/search/page.tsx
+++ b/fe/src/app/search/page.tsx
@@ -13,7 +13,6 @@ export default function SearchPage() {
   const { isGuest } = useAuth();
   const [inputValue, setInputValue] = useState("");
   const [confirmedKeyword, setConfirmedKeyword] = useState("");
-  const [active, setActive] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -30,12 +29,6 @@ export default function SearchPage() {
     router.push(isGuest ? "/guest" : "/member");
   };
 
-  const handleTouchStart = () => {
-    if (inputRef.current) {
-      inputRef.current.focus();
-    }
-  };
-
   const clearSearch = () => {
     setInputValue("");
     setConfirmedKeyword("");
@@ -47,6 +40,8 @@ export default function SearchPage() {
       <button
         onClick={clearSearch}
         className="absolute right-3 top-1/2 -translate-y-1/2"
+        aria-label="검색어 지우기"
+        type="button"
       >
         <Image
           src="/images/deleteicon.svg"
@@ -61,7 +56,7 @@ export default function SearchPage() {
   return (
     <div className="h-full bg-bgColor-default p-4 space-y-4">
       <div className="flex items-center gap-2">
-        <button onClick={handleBack}>
+        <button onClick={handleBack} type="button">
           <BackIcon className="w-10 h-10 text-textColor-body" />
         </button>
         <div className="flex-1 relative text-textColor-body">
@@ -74,7 +69,6 @@ export default function SearchPage() {
               if (confirmedKeyword) setConfirmedKeyword("");
             }}
             onKeyDown={(e) => e.key === "Enter" && handleSearch(inputValue)}
-            onTouchStart={handleTouchStart}
             placeholder="검색어를 입력하세요"
             aria-label="검색어 입력"
             inputMode="search"
@@ -88,10 +82,8 @@ export default function SearchPage() {
               appearance: "none",
               WebkitOverflowScrolling: "touch",
               touchAction: "manipulation",
-              caretColor: active ? "auto" : "transparent",
+              caretColor: "auto",
             }}
-            onFocus={() => setActive(true)}
-            onBlur={() => setActive(false)}
           />
           {clearButton}
         </div>

--- a/fe/src/components/home/ActivityCardListBase.tsx
+++ b/fe/src/components/home/ActivityCardListBase.tsx
@@ -72,8 +72,11 @@ export default function ActivityCardListBase({
   return (
     <section className="flex flex-col items-center gap-5">
       {isLoading && (
-        <div className="py-10">
-          <div className="h-10 w-10 animate-spin rounded-full border-b-2 border-brand-normal" />
+        <div className="flex flex-col justify-center items-center w-full min-h-[60vh]">
+          <div className="h-10 w-10 animate-spin rounded-full border-b-2 border-brand-normal mb-6" />
+          <p className="text-xl font-semibold text-brand-normal text-center">
+            활동을 불러오는 중입니다!
+          </p>
         </div>
       )}
 


### PR DESCRIPTION
## 📝 PR 내용 요약

- 검색 페이지의 코드 구조를 개선하고,
- 활동 카드 로딩 시 UI 깨짐 현상을 수정했습니다.

## ✅ 작업 상세

- /search/page.tsx 에서 불필요한 상태 및 핸들러 제거, 코드 가독성 개선
- 모바일 터치 UX 관련 인라인 스타일 유지
- 활동 카드 로딩 시 스피너가 항상 중앙에 보이도록 min-h, flex 정력 적용
- 로딩 중 "활동을 불러오는 중입니다" 안내 멘트 추가 및 스타일 개선 

## #️⃣ 연관 이슈

Closes #71 

## 🖼️ 변경된 화면 (선택)

> ![image](https://github.com/user-attachments/assets/d205dcfa-4e1f-459b-b550-37b62c59482c)

## 💬 기타 논의 사항 (선택)

- 로딩 영역의 min-h 값(60vh)이 적절한지, 혹은 더 조정이 필요한지 논의 필요

## 💬 리뷰 요구사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 검색 입력창의 포커스 및 커서 색상 관련 동작이 단순화되어, 입력창 사용 시 일관된 경험을 제공합니다.
  - 버튼에 접근성 향상을 위한 `aria-label`과 `type="button"` 속성이 추가되었습니다.

- **스타일**
  - 활동 카드 목록의 로딩 화면이 개선되어, 중앙 정렬된 스피너와 함께 "활동을 불러오는 중입니다!" 안내 문구가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->