### PR TITLE
[feat] 가족 수정하기 버튼 삭제api 연결 

### DIFF
--- a/fe/src/components/chatbot/messages/ChatbotMessageList.tsx
+++ b/fe/src/components/chatbot/messages/ChatbotMessageList.tsx
@@ -48,7 +48,6 @@ const ChatbotMessageList = () => {
     fetchUserName();
   }, []);
 
-  
   useEffect(() => {
     const fetchCurrentMBTI = async () => {
       if (isFirstRender.current) {

--- a/fe/src/components/chatbot/messages/ChatbotMessageList.tsx
+++ b/fe/src/components/chatbot/messages/ChatbotMessageList.tsx
@@ -48,7 +48,7 @@ const ChatbotMessageList = () => {
     fetchUserName();
   }, []);
 
-  // 채팅방 입장 시 현재 MBTI 조회
+  
   useEffect(() => {
     const fetchCurrentMBTI = async () => {
       if (isFirstRender.current) {

--- a/fe/src/components/family/link/FamilyLinkStep1.tsx
+++ b/fe/src/components/family/link/FamilyLinkStep1.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import BottomButton from "@/components/common/button/BottomButton";
 
 interface FamilyLinkStep1Props {
@@ -11,14 +11,6 @@ export default function FamilyLinkStep1({
   onSelectRelation,
 }: FamilyLinkStep1Props) {
   const [relation, setRelation] = useState<"parent" | "child" | null>(null);
-
-  useEffect(() => {
-    // 페이지 로드 시 localStorage에서 관계 정보 확인
-    const savedRelation = localStorage.getItem("familyRelation");
-    if (savedRelation === "parent" || savedRelation === "child") {
-      setRelation(savedRelation);
-    }
-  }, []);
 
   const handleSelectRelation = (selectedRelation: "parent" | "child") => {
     setRelation(selectedRelation);

--- a/fe/src/components/family/link/FamilyLinkStep2.tsx
+++ b/fe/src/components/family/link/FamilyLinkStep2.tsx
@@ -2,10 +2,12 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import axios from "axios";
 import FamilyCompletedMessage from "@/components/family/common/CompletedMessage";
 import BottomButton from "@/components/common/button/BottomButton";
 import { verifyRelation } from "@/apis/family/link";
 import CompletionNotice from "@/components/personality/analysis/CompletionNotice";
+import Toast from "@/components/common/Toast"; 
 import FamilyHeader from "@/components/family/common/FamilyHeader";
 import Image from "next/image";
 
@@ -24,6 +26,7 @@ export default function FamilyLinkStep2({
     "NEW_USER" | "EXISTING_USER" | "NEED_PERSONALITY" | null
   >(null);
   const [error, setError] = useState("");
+  const [toastMessage, setToastMessage] = useState("");
 
   const clearCode = () => {
     setCode("");
@@ -64,7 +67,29 @@ export default function FamilyLinkStep2({
       }
     } catch (err) {
       console.error("가족 연동 에러:", err);
-      setError("서버 오류가 발생했습니다.");
+
+      if (axios.isAxiosError(err)) {
+        const data = err.response?.data as { code?: string; message?: string };
+      
+        const code = data?.code;
+      
+        switch (code) {
+          case "SELF_RELATION_NOT_ALLOWED":
+            setToastMessage("자기 자신과는 가족으로 연동할 수 없어요.");
+            break;
+          case "MULTIPLE_PHONE_ERROR":
+            setToastMessage("동일한 번호로는 여러 가족을 연동할 수 없어요.");
+            break;
+          case "RELATED_USER_ALREADY_CONNECTED":
+            setToastMessage("입력한 고유번호는 이미 다른 가족과 연동되어 있어요.");
+            break;
+          default:
+            setToastMessage(data?.message || "예상치 못한 오류가 발생했어요.");
+            break;
+        }
+      } else {
+        setToastMessage("네트워크 오류가 발생했어요. 다시 시도해주세요.");
+      }
     }
   };
 
@@ -151,6 +176,13 @@ export default function FamilyLinkStep2({
       <BottomButton onClick={handleNext} disabled={!code}>
         연동하기
       </BottomButton>
+
+      {toastMessage && (
+      <Toast
+        message={toastMessage}
+        onClose={() => setToastMessage("")}
+      />
+    )}
     </div>
   );
 }

--- a/fe/src/components/family/link/FamilyLinkStep2.tsx
+++ b/fe/src/components/family/link/FamilyLinkStep2.tsx
@@ -7,7 +7,7 @@ import FamilyCompletedMessage from "@/components/family/common/CompletedMessage"
 import BottomButton from "@/components/common/button/BottomButton";
 import { verifyRelation } from "@/apis/family/link";
 import CompletionNotice from "@/components/personality/analysis/CompletionNotice";
-import Toast from "@/components/common/Toast"; 
+import Toast from "@/components/common/Toast";
 import FamilyHeader from "@/components/family/common/FamilyHeader";
 import Image from "next/image";
 
@@ -70,9 +70,9 @@ export default function FamilyLinkStep2({
 
       if (axios.isAxiosError(err)) {
         const data = err.response?.data as { code?: string; message?: string };
-      
+
         const code = data?.code;
-      
+
         switch (code) {
           case "SELF_RELATION_NOT_ALLOWED":
             setToastMessage("자기 자신과는 가족으로 연동할 수 없어요.");
@@ -81,7 +81,9 @@ export default function FamilyLinkStep2({
             setToastMessage("동일한 번호로는 여러 가족을 연동할 수 없어요.");
             break;
           case "RELATED_USER_ALREADY_CONNECTED":
-            setToastMessage("입력한 고유번호는 이미 다른 가족과 연동되어 있어요.");
+            setToastMessage(
+              "입력한 고유번호는 이미 다른 가족과 연동되어 있어요.",
+            );
             break;
           default:
             setToastMessage(data?.message || "예상치 못한 오류가 발생했어요.");
@@ -178,11 +180,8 @@ export default function FamilyLinkStep2({
       </BottomButton>
 
       {toastMessage && (
-      <Toast
-        message={toastMessage}
-        onClose={() => setToastMessage("")}
-      />
-    )}
+        <Toast message={toastMessage} onClose={() => setToastMessage("")} />
+      )}
     </div>
   );
 }

--- a/fe/src/components/family/link/FamilyLinkStep2.tsx
+++ b/fe/src/components/family/link/FamilyLinkStep2.tsx
@@ -125,7 +125,7 @@ export default function FamilyLinkStep2({
               value={code}
               onChange={(e) => setCode(e.target.value)}
               placeholder="고유번호 입력"
-              className="w-full h-[65px] px-4 pr-10 text-lg border-2 border-brand-normal focus:border-brand-normal focus:outline-none rounded-xl"
+              className="w-full h-[65px] px-4 pr-10 text-lg border-2 border-gray-300 focus:border-brand-normal focus:outline-none rounded-xl"
             />
             {code && (
               <button

--- a/fe/src/components/family/popup/FamilyDeleteConfirmPopup.tsx
+++ b/fe/src/components/family/popup/FamilyDeleteConfirmPopup.tsx
@@ -3,7 +3,7 @@
 import { useRouter } from "next/navigation";
 import BottomPopup from "@/components/common/popup/BottomPopup";
 import PopupButtons from "@/components/common/button/PopupButtons";
-import { Calendar, X } from "lucide-react";
+import { AlertTriangle, X } from "lucide-react";
 import axiosMainInstance from "@/apis/common/axiosMainInstance";
 
 interface FamilyDeleteConfirmPopupProps {
@@ -38,7 +38,7 @@ export default function FamilyDeleteConfirmPopup({
           <X className="w-6 h-6 text-iconColor-sub" />
         </button>
 
-        <Calendar className="w-10 h-10 text-brand-normal" />
+        <AlertTriangle className="w-10 h-10 text-brand-normal" />
 
         <h2 className="text-2xl font-semibold text-textColor-heading">
           가족 정보를 수정할까요?

--- a/fe/src/components/family/popup/FamilyDeleteConfirmPopup.tsx
+++ b/fe/src/components/family/popup/FamilyDeleteConfirmPopup.tsx
@@ -4,21 +4,27 @@ import { useRouter } from "next/navigation";
 import BottomPopup from "@/components/common/popup/BottomPopup";
 import PopupButtons from "@/components/common/button/PopupButtons";
 import { Calendar, X } from "lucide-react";
+import axiosMainInstance from "@/apis/common/axiosMainInstance";
 
-interface FamilyLinkPopupProps {
+interface FamilyDeleteConfirmPopupProps {
   isOpen: boolean;
   onClose: () => void;
 }
 
-export default function FamilyLinkPopup({
+export default function FamilyDeleteConfirmPopup({
   isOpen,
   onClose,
-}: FamilyLinkPopupProps) {
+}: FamilyDeleteConfirmPopupProps) {
   const router = useRouter();
 
-  const handleAddFamily = () => {
-    onClose();
-    router.replace("/member/family");
+  const handleDeleteAndRedirect = async () => {
+    try {
+      await axiosMainInstance.delete("/v1/user/relation/delete");
+      onClose();
+      router.replace("/member/family");
+    } catch (error) {
+      console.error("❌ 가족 삭제 실패:", error);
+    }
   };
 
   return (
@@ -35,18 +41,18 @@ export default function FamilyLinkPopup({
         <Calendar className="w-10 h-10 text-brand-normal" />
 
         <h2 className="text-2xl font-semibold text-textColor-heading">
-          계정에 가족을 추가해보세요
+          가족 정보를 수정할까요?
         </h2>
 
         <p className="text-base text-textColor-sub leading-relaxed whitespace-pre-line">
-          가족을 추가하면 함께{"\n"}일정을 공유할 수 있어요!
+          수정하면 기존 가족 정보는 삭제되고{"\n"}새로운 가족을 연동할 수 있어요.
         </p>
 
         <PopupButtons
-          onConfirm={handleAddFamily}
+          onConfirm={handleDeleteAndRedirect}
           onCancel={onClose}
-          confirmLabel="가족 추가하기"
-          cancelLabel="건너뛰기"
+          confirmLabel="가족 수정하기"
+          cancelLabel="취소"
         />
       </div>
     </BottomPopup>

--- a/fe/src/components/family/popup/FamilyDeleteConfirmPopup.tsx
+++ b/fe/src/components/family/popup/FamilyDeleteConfirmPopup.tsx
@@ -45,7 +45,8 @@ export default function FamilyDeleteConfirmPopup({
         </h2>
 
         <p className="text-base text-textColor-sub leading-relaxed whitespace-pre-line">
-          수정하면 기존 가족 정보는 삭제되고{"\n"}새로운 가족을 연동할 수 있어요.
+          수정하면 기존 가족 정보는 삭제되고{"\n"}새로운 가족을 연동할 수
+          있어요.
         </p>
 
         <PopupButtons

--- a/fe/src/components/mypage/button/FamilyAddButton.tsx
+++ b/fe/src/components/mypage/button/FamilyAddButton.tsx
@@ -2,38 +2,45 @@
 
 import { useState } from "react";
 import FamilyLinkPopup from "@/components/family/popup/FamilyLinkPopup";
+import FamilyDeleteConfirmPopup from "@/components/family/popup/FamilyDeleteConfirmPopup";
 
 interface FamilyAddButtonProps {
   hasFamily: boolean;
 }
 
 const FamilyAddButton = ({ hasFamily }: FamilyAddButtonProps) => {
-  const [isPopupOpen, setIsPopupOpen] = useState(false);
+  const [isLinkPopupOpen, setIsLinkPopupOpen] = useState(false);
+  const [isDeletePopupOpen, setIsDeletePopupOpen] = useState(false);
 
-  const handleOpenPopup = () => {
-    setIsPopupOpen(true);
+  const handleClick = () => {
+    if (hasFamily) {
+      
+      setIsDeletePopupOpen(true);
+    } else {
+     
+      setIsLinkPopupOpen(true);
+    }
   };
 
-  const handleClosePopup = () => {
-    setIsPopupOpen(false);
-  };
+  const closeLinkPopup = () => setIsLinkPopupOpen(false);
+  const closeDeletePopup = () => setIsDeletePopupOpen(false);
 
   return (
     <>
       <button
-        onClick={handleOpenPopup}
+        onClick={handleClick}
         className={`h-[55px] min-w-[330px] px-6 shadow-header 
         rounded-xl bg-brand-normal text-white text-2xl font-semibold font-pretendard 
         whitespace-nowrap flex items-center justify-center`}
       >
-        {hasFamily ? "가족수정하기" : "가족추가하기"}
+        {hasFamily ? "가족 수정하기" : "가족 추가하기"}
       </button>
 
-      <FamilyLinkPopup
-        isOpen={isPopupOpen}
-        onClose={handleClosePopup}
-        hasFamily={hasFamily}
-      />
+      
+      <FamilyLinkPopup isOpen={isLinkPopupOpen} onClose={closeLinkPopup} />
+
+      
+      <FamilyDeleteConfirmPopup isOpen={isDeletePopupOpen} onClose={closeDeletePopup} />
     </>
   );
 };

--- a/fe/src/components/mypage/button/FamilyAddButton.tsx
+++ b/fe/src/components/mypage/button/FamilyAddButton.tsx
@@ -14,10 +14,8 @@ const FamilyAddButton = ({ hasFamily }: FamilyAddButtonProps) => {
 
   const handleClick = () => {
     if (hasFamily) {
-      
       setIsDeletePopupOpen(true);
     } else {
-     
       setIsLinkPopupOpen(true);
     }
   };
@@ -36,11 +34,12 @@ const FamilyAddButton = ({ hasFamily }: FamilyAddButtonProps) => {
         {hasFamily ? "가족 수정하기" : "가족 추가하기"}
       </button>
 
-      
       <FamilyLinkPopup isOpen={isLinkPopupOpen} onClose={closeLinkPopup} />
 
-      
-      <FamilyDeleteConfirmPopup isOpen={isDeletePopupOpen} onClose={closeDeletePopup} />
+      <FamilyDeleteConfirmPopup
+        isOpen={isDeletePopupOpen}
+        onClose={closeDeletePopup}
+      />
     </>
   );
 };

--- a/fe/src/hooks/chatbot/useChatbot.ts
+++ b/fe/src/hooks/chatbot/useChatbot.ts
@@ -137,7 +137,8 @@ export function useChatbot() {
         return;
       }
 
-      const activityMsg = recMsgs[1] as import("@/types/chatbot").ActivityMessage;
+      const activityMsg =
+        recMsgs[1] as import("@/types/chatbot").ActivityMessage;
       if (activityMsg) {
         setLastRecommendedProgramId(activityMsg.programId);
         saveProgramId(activityMsg.programId);

--- a/fe/src/hooks/chatbot/useChatbot.ts
+++ b/fe/src/hooks/chatbot/useChatbot.ts
@@ -137,8 +137,7 @@ export function useChatbot() {
         return;
       }
 
-      const activityMsg =
-        recMsgs[0] as import("@/types/chatbot").ActivityMessage;
+      const activityMsg = recMsgs[1] as import("@/types/chatbot").ActivityMessage;
       if (activityMsg) {
         setLastRecommendedProgramId(activityMsg.programId);
         saveProgramId(activityMsg.programId);

--- a/fe/src/hooks/chatbot/useSchedule.ts
+++ b/fe/src/hooks/chatbot/useSchedule.ts
@@ -29,7 +29,9 @@ export function useSchedule() {
       console.error(" 일정 저장 실패", e);
       const errorMessage = (e as Error).message;
       if (errorMessage.includes("이미 등록된 일정입니다")) {
-        return [makeBotText("이미 등록된 일정이에요! 다른 궁금한 점을 입력해주세요!")];
+        return [
+          makeBotText("이미 등록된 일정이에요! 다른 궁금한 점을 입력해주세요!"),
+        ];
       }
       return [makeBotText(errorMessage)];
     } finally {

--- a/fe/src/hooks/chatbot/useSchedule.ts
+++ b/fe/src/hooks/chatbot/useSchedule.ts
@@ -27,7 +27,11 @@ export function useSchedule() {
       return [];
     } catch (e) {
       console.error(" 일정 저장 실패", e);
-      return [makeBotText((e as Error).message)];
+      const errorMessage = (e as Error).message;
+      if (errorMessage.includes("이미 등록된 일정입니다")) {
+        return [makeBotText("이미 등록된 일정이에요! 다른 궁금한 점을 입력해주세요!")];
+      }
+      return [makeBotText(errorMessage)];
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION

## 📝 PR 내용 요약

* 가족 수정하기 팝업 추가 및 삭제 API 연동
* 상대방이 이미 연동되어 있을 경우 토스트 문구 표시 추가

## ✅ 작업 상세

* `FamilyDeleteConfirmPopup` 컴포넌트 생성 및 연동
* 기존 `FamilyLinkPopup` 분리 → 가족 추가/수정 흐름 명확히 분리
* `가족 수정하기` 버튼 클릭 시 삭제 확인 팝업으로 전환
* 삭제 성공 시 `/member/family`로 리다이렉트
* 상대방이 이미 연동된 상태일 경우:
  * 서버 응답을 기반으로 오류 메시지 토스트 표시

## #️⃣ 연관 이슈

> Closes #68 

## 🖼️ 변경된 화면 (선택)


## 💬 기타 논의 사항 (선택)


## 💬 리뷰 요구사항 (선택)

* 삭제 API 연동 및 상태 전환 흐름 자연스러운지
* 팝업 전환 타이밍/겹침 여부 문제 없는지
* 토스트 메시지 위치 및 문구 적절한지 확인 부탁드립니다




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 가족 정보 삭제를 위한 확인 팝업이 추가되었습니다.

- **버그 수정**
  - 가족 관계 인증 과정에서 발생하는 오류에 대해 더 구체적인 안내 메시지가 토스트로 표시됩니다.
  - 챗봇 일정 등록 시 이미 등록된 일정에 대한 안내 메시지가 명확하게 제공됩니다.

- **기능 개선**
  - 가족 추가/삭제 버튼 클릭 시, 상황에 따라 별도의 팝업이 표시되어 보다 직관적인 동작을 제공합니다.
  - 가족 추가 팝업이 "가족 정보 추가" 상황만 지원하도록 UI와 텍스트가 단순화되었습니다.

- **사용성 변경**
  - 가족 관계 선택 시 이전에 저장된 관계가 자동으로 복원되지 않습니다.
  - 챗봇 추천 메시지 선택 시, 두 번째 메시지가 사용됩니다.

- **기타**
  - 불필요한 주석 및 사용하지 않는 코드가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->